### PR TITLE
Remove data ack to improve performance

### DIFF
--- a/inc/sock.h
+++ b/inc/sock.h
@@ -3,7 +3,12 @@
 
 #define TIMEOUT 1000000
 
+#include <errno.h>
+#include <sys/types.h>
+
 int open_clientfd(char *hostname, char *port) __attribute__((unused));
 int open_listenfd(char *port) __attribute__((unused));
+ssize_t retry_recv(int sock_fd, void *buf, size_t len, int flags);
+ssize_t retry_send(int sock_fd, const void *buf, size_t len, int flags);
 
 #endif

--- a/src/sender.c
+++ b/src/sender.c
@@ -193,7 +193,7 @@ int send_data(int sender_fd, char *fname, char *pub_key, char sha256_str[65]) {
 
     // Send data header
     create_header(&header, kOpData, kData, seg_len);
-    status = send(sender_fd, header, HEADER_LENGTH, 0);
+    status = retry_send(sender_fd, header, HEADER_LENGTH, 0);
     free(header);
     if (status == -1) {
       error(sender_fd, "send data header failed");
@@ -204,24 +204,13 @@ int send_data(int sender_fd, char *fname, char *pub_key, char sha256_str[65]) {
 
     //  Send data paylaod
     create_payload(&payload, 0, seg_len, data_seg);
-    status = send(sender_fd, payload, GET_PAYLOAD_PACKET_LEN(seg_len), 0);
+    status = retry_send(sender_fd, payload, GET_PAYLOAD_PACKET_LEN(seg_len), 0);
     free(payload);
     if (status == -1) {
       error(sender_fd, "send data failed");
       return -1;
     } else {
       info(sender_fd, "send data success");
-    }
-    //  Receive ack
-    header = malloc(HEADER_LENGTH);
-    status = recv(sender_fd, header, HEADER_LENGTH, 0);
-    opcode_t opcode = get_opcode(header);
-    free(header);
-    if (status == -1 || opcode != kOpAck) {
-      error(sender_fd, "recv ack failed");
-      return -1;
-    } else {
-      info(sender_fd, "recv ack success");
     }
 
     if (last_seg) break;

--- a/src/sock.c
+++ b/src/sock.c
@@ -1,6 +1,8 @@
 #include "sock.h"
 
+#include <errno.h>
 #include <netdb.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -61,4 +63,42 @@ int open_listenfd(char *port) {
     return -1;
   }
   return listenfd;
+}
+
+ssize_t retry_recv(int sock_fd, void *buf, size_t len, int flags) {
+  ssize_t received_len = 0;
+  while (received_len != (ssize_t)len) {
+    void *recv_buf = (void *)((uintptr_t)buf + received_len);
+    ssize_t ret = recv(sock_fd, recv_buf, len - received_len, flags);
+    if (ret > 0)
+      received_len += ret;
+    else {
+      if ((ret == -1) && ((errno == EINTR) || (errno == EAGAIN)))
+        continue;
+      else {
+        received_len = ret;
+        break;
+      }
+    }
+  }
+  return received_len;
+}
+
+ssize_t retry_send(int sock_fd, const void *buf, size_t len, int flags) {
+  ssize_t sent_len = 0;
+  while (sent_len != (ssize_t)len) {
+    const void *send_buf = (void *)((uintptr_t)buf + sent_len);
+    ssize_t ret = send(sock_fd, send_buf, len - sent_len, flags);
+    if (ret > 0)
+      sent_len += ret;
+    else {
+      if ((ret == -1) && ((errno == EINTR) || (errno == EAGAIN)))
+        continue;
+      else {
+        sent_len = ret;
+        break;
+      }
+    }
+  }
+  return sent_len;
 }


### PR DESCRIPTION
Add `retry_send`, `retry_recv` functions to prevent unexpected data lengths.